### PR TITLE
link DOIs against preferred resolver

### DIFF
--- a/tex/Code_Report.tex
+++ b/tex/Code_Report.tex
@@ -447,7 +447,7 @@ moredelim=**[is][{\btHL[fill=green!30]}]{<*@}{@*>},
 
 
 %-----其他设定-----
-\newcommand{\doi}[2]{\href{http://dx.doi.org/#1}{#2}}
+\newcommand{\doi}[2]{\href{https://doi.org/#1}{#2}}
 \usepackage[version=4]{mhchem}
 \mhchemoptions{textfontcommand=\sffamily}
 \mhchemoptions{mathfontcommand=\mathsf}


### PR DESCRIPTION
Hello!

The DOI foundation recommends a [new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).

Cheers :-)